### PR TITLE
Fix Windows filename error in Bulk Campaign Export

### DIFF
--- a/server.js
+++ b/server.js
@@ -4339,7 +4339,7 @@ async function runBulkCampaignExport(config) {
       fs.mkdirSync(campaignDir, { recursive: true });
 
       const safeName = (campaign.name || 'Unnamed').replace(/[^a-zA-Z0-9-_ ]/g, '_').substring(0, 100);
-      const filename = `${safeName}_${targetDate}.csv`;
+      const filename = `${safeName}_${targetDate}.csv`.replace(/[<>:"\/\\|?*]/g, '-');
       const filePath = path.join(campaignDir, filename);
 
       log(`\n[${i + 1}/${campaigns.length}] ${campaign.name || 'Unnamed'}`);


### PR DESCRIPTION
Fixes #15.

Bulk Campaign Export filenames were built as `${safeName}_${targetDate}.csv`. The campaign name was sanitized, but `targetDate` was not. For at least one campaign, `campaign.target_date` came back as a full ISO timestamp (e.g. `2026-04-20T14:00:29.000Z`) instead of `YYYY-MM-DD` - the colons in that string are legal in macOS paths but not Windows paths, causing the reported ENOENT error.

Fix: sanitize the entire generated filename against Windows-reserved characters, not just the campaign-name portion, so this is safe regardless of what shape the API returns for target_date.

This is a draft PR for review before merging.