### PR TITLE
Fix same-day re-attempt classification to use calendar day

### DIFF
--- a/businessReview.js
+++ b/businessReview.js
@@ -1137,7 +1137,7 @@ async function generateBusinessReviewSlides(stats, outputPath, logoPath, squareL
   const s4SinglePct = s4TotalNumbers > 0 ? (cadence.cadenceSingleTouch / s4TotalNumbers * 100).toFixed(1) : '0.0';
   const s4MultiPct  = s4TotalNumbers > 0 ? (cadence.cadenceMultiTouchCount / s4TotalNumbers * 100).toFixed(1) : '0.0';
   s4.addText(
-    `${cadence.cadenceMultiTouchCount.toLocaleString()} numbers (${s4MultiPct}%) had 2+ delivery attempts – across all result types (successfully delivered, unsuccessful, voicemail not setup, voicemail full, and not in service). ${cadence.cadenceSingleTouch.toLocaleString()} numbers (${s4SinglePct}%) were contacted only once – each a potential opportunity for an additional touch. Breakdown by median interval between consecutive attempts:`,
+    `${cadence.cadenceMultiTouchCount.toLocaleString()} numbers (${s4MultiPct}%) had 2+ delivery attempts – across all result types (successfully delivered, unsuccessful, voicemail not setup, voicemail full, and not in service). ${cadence.cadenceSingleTouch.toLocaleString()} numbers (${s4SinglePct}%) were contacted only once – each a potential opportunity for an additional touch. Breakdown by median interval between consecutive attempts (Same-day reflects any pair on the same calendar date):`,
     {
       x: 1.8, y: s4CY + 0.08,
       w: SLIDE_W - 3.6, h: 0.44,
@@ -1147,7 +1147,7 @@ async function generateBusinessReviewSlides(stats, outputPath, logoPath, squareL
   );
 
   const cadenceRows = [
-    { label: 'Same-day re-attempt  (< 1 day)', count: cadence.cadenceBucket_sameDay,  ideal: false, warn: true,  note: false, long: false },
+    { label: 'Same-day re-attempt (same calendar date)', count: cadence.cadenceBucket_sameDay,   ideal: false, warn: true,  note: false, long: false },
     { label: '1–2 days',                       count: cadence.cadenceBucket_1to2,      ideal: false, warn: true,  note: false, long: false },
     { label: '3–5 days',                       count: cadence.cadenceBucket_3to5,      ideal: true,  warn: false, note: false, long: false },
     { label: '6–10 days',                      count: cadence.cadenceBucket_6to10,     ideal: true,  warn: false, note: false, long: false },

--- a/trendAnalyzer.js
+++ b/trendAnalyzer.js
@@ -1273,7 +1273,7 @@ async function generateTrendAnalysis(
   // ============================================================================
   log('Computing delivery cadence stats...');
   let cadenceSingleTouch = 0;
-  let cadenceBucket_sameDay = 0; // < 1 day
+  let cadenceBucket_sameDay = 0; // any pair on the same calendar date
   let cadenceBucket_1to2    = 0; // 1–2 days
   let cadenceBucket_3to5    = 0; // 3–5 days
   let cadenceBucket_6to10   = 0; // 6–10 days
@@ -1288,9 +1288,11 @@ async function generateTrendAnalysis(
     // Ensure time-ordered – streaming path already sorted in place; row-array path may not be
     if (atts[0].ts > atts[atts.length - 1].ts) atts.sort((a, b) => a.ts - b.ts);
     const intervals = [];
+    let hasSameDayPair = false; // true if any consecutive pair fell on the same calendar date
     for (let i = 1; i < atts.length; i++) {
       const diff = (atts[i].ts - atts[i - 1].ts) / 86400000; // ms → days
       if (diff >= 0) intervals.push(diff);
+      if (atts[i].dateStr && atts[i].dateStr === atts[i - 1].dateStr) hasSameDayPair = true;
     }
     if (intervals.length === 0) { cadenceSingleTouch++; continue; }
     intervals.sort((a, b) => a - b);
@@ -1299,7 +1301,7 @@ async function generateTrendAnalysis(
       ? (intervals[cMid - 1] + intervals[cMid]) / 2
       : intervals[cMid];
     _cadenceMedians.push(med);
-    if      (med < 1)   cadenceBucket_sameDay++;
+    if (hasSameDayPair)   cadenceBucket_sameDay++;
     else if (med <= 2)  cadenceBucket_1to2++;
     else if (med <= 5)  cadenceBucket_3to5++;
     else if (med <= 10) cadenceBucket_6to10++;
@@ -2097,10 +2099,10 @@ async function generateTrendAnalysis(
         'Numbers reached with a single DDVM during this period. Consumers often need 2–3 touches before taking action – a callback, a payment, or a response rarely happens the first time a message is heard. These numbers represent real follow-up opportunity: adding a second or third DDVM attempt at the right cadence (3–10 days) typically produces meaningful incremental results without diminishing returns.'],
       ['Re-attempted (2+ attempts)',
         `${cadenceMultiTouchCount.toLocaleString()} (${cadenceTotalNumbers > 0 ? (cadenceMultiTouchCount / cadenceTotalNumbers * 100).toFixed(1) : '0.0'}%)`,
-        'Numbers with multiple attempts. Cadence breakdown below is based on the median interval between consecutive attempts for each number.'],
-      ['  Same-day re-attempt (< 1 day)',
+        'Numbers with multiple attempts. Cadence tiers below are based on the median interval between consecutive attempts for each number, except Same-day re-attempt, which flags any number with at least one re-attempt pair on the same calendar date.'],
+      [' Same-day re-attempt (same calendar date)',
         `${cadenceBucket_sameDay.toLocaleString()} (${(cadenceBucket_sameDay / cadenceMultiTouchCount * 100).toFixed(1)}% of re-attempted)`,
-        'Numbers typically re-attempted on the same calendar day. Same-day re-attempts are rarely effective and may indicate a campaign configuration issue.'],
+        'Numbers with at least one re-attempt pair on the same calendar date, regardless of the median interval for that number. Same-day re-attempts are rarely effective and may indicate a campaign configuration issue.'],
       ['  1–2 days',
         `${cadenceBucket_1to2.toLocaleString()} (${(cadenceBucket_1to2 / cadenceMultiTouchCount * 100).toFixed(1)}% of re-attempted)`,
         'Very short interval after a successful delivery. Re-attempting a number the day after a successful drop does not give the consumer time to respond and can accelerate list fatigue. Note: re-attempting a number the day after an unsuccessful delivery attempt is perfectly acceptable – this flag is relevant only when the prior attempt succeeded.'],

--- a/trendAnalyzer.js
+++ b/trendAnalyzer.js
@@ -888,7 +888,8 @@ async function generateTrendAnalysis(
                   ts:          pdOk ? parsedDate.getTime() : 0,
                   isSuccess,
                   result:      resultNorm,
-                  attemptIndex: nd.attemptIndex   // already incremented above
+                  attemptIndex: nd.attemptIndex, // already incremented above
+                      dateStr: parsed ? parsed.localDateStr : (pdOk ? parsedDate.toISOString().slice(0, 10) : null)
                 });
               }
               if (isDelivery) {
@@ -1152,7 +1153,8 @@ async function generateTrendAnalysis(
           ts:          row.parsedMs || 0,
           isSuccess:   row.isSuccess,
           result:      row.voapps_result_normalized,
-          attemptIndex: nd.attemptIndex   // already incremented above
+          attemptIndex: nd.attemptIndex,   // already incremented above
+          dateStr: row.localDateStr
         });
       }
 
@@ -1426,7 +1428,7 @@ async function generateTrendAnalysis(
         // Timing bucket
         if (timingMatrix[from]) {
           const diffDays = (atts[i + 1].ts - atts[i].ts) / 86400000;
-          const bucket = diffDays < 1      ? 'sameDay'
+          const bucket = (atts[i].dateStr && atts[i].dateStr === atts[i + 1].dateStr) ? 'sameDay'
                        : diffDays <= 2     ? 'day1to2'
                        : diffDays <= 3     ? 'day2to3'
                        : diffDays <= 7     ? 'day4to7'


### PR DESCRIPTION
Fixes #14.

Two consecutive attempts were classified as "sameDay" if they were less than 24 raw hours apart, so 11pm/1am counted as same-day while 9am/11pm on the same date did not.

Attempts now carry a dateStr (their local calendar date) and the sameDay bucket in the re-attempt timing matrix is assigned by comparing that date directly instead of elapsed hours.

Also updated the separate cadenceBucket_sameDay stat (used on the Business Review Delivery Cadence slide/chart), which previously bucketed by the median of a number's interval gaps rather than a single pair. A number now falls into Same-day re-attempt if ANY consecutive attempt pair occurred on the same calendar date, regardless of the median. Documentation in the Excel report and Business Review deck updated to match. See PR comment below for full details on this change.

This is a draft PR for review before merging.